### PR TITLE
Release 2.0.6

### DIFF
--- a/202/build.xml
+++ b/202/build.xml
@@ -23,7 +23,7 @@
     <property name="src-dir" value="${basedir}"/>
     <property name="TARGETNAME" value="axeptiocookies"/>
     <property name="TARGETBRANCH" value="${env.GIT_BRANCH}"/>
-    <property name="TARGETVERSION" value="2.0.5"/>
+    <property name="TARGETVERSION" value="2.0.6"/>
 
     <target name="build" depends="build-common,package-zip,psvalidator"/>
 

--- a/202/phpstan/phpstan.neon
+++ b/202/phpstan/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
       - ../../controllers
       - ../../override
       - ../../src
+  ignoreErrors:
+      - '~^Call to an undefined method Smarty_Internal_Data::fetch\(\)\.$~'
 
   reportUnmatchedIgnoredErrors: false
   level: 3

--- a/axeptiocookies.php
+++ b/axeptiocookies.php
@@ -108,7 +108,7 @@ class Axeptiocookies extends Module
     public function __construct()
     {
         $this->name = 'axeptiocookies';
-        $this->version = '2.0.6';
+        $this->version = '@version@';
         $this->author = '202 ecommerce';
         $this->tab = 'front_office_features';
         $this->ps_versions_compliancy = [

--- a/axeptiocookies.php
+++ b/axeptiocookies.php
@@ -108,7 +108,7 @@ class Axeptiocookies extends Module
     public function __construct()
     {
         $this->name = 'axeptiocookies';
-        $this->version = '@version@';
+        $this->version = '2.0.6';
         $this->author = '202 ecommerce';
         $this->tab = 'front_office_features';
         $this->ps_versions_compliancy = [

--- a/config/common.yml
+++ b/config/common.yml
@@ -1,4 +1,5 @@
 imports:
+  - { resource: partials/template.yml }
   - { resource: partials/repository.yml }
   - { resource: partials/service.yml }
   - { resource: partials/update.yml }

--- a/config/partials/template.yml
+++ b/config/partials/template.yml
@@ -1,0 +1,14 @@
+services:
+  AxeptiocookiesAddon\Factory\TemplateReplacementFactory:
+    class: AxeptiocookiesAddon\Factory\TemplateReplacementFactory
+    public: true
+
+  AxeptiocookiesAddon\Handler\Template\AbstractTemplateHandler:
+    class: AxeptiocookiesAddon\Handler\Template\AbstractTemplateHandler
+    abstract: true
+    public: true
+
+  AxeptiocookiesAddon\Handler\Template\PsGoogleAnalyticsTemplateHandler:
+    class: AxeptiocookiesAddon\Handler\Template\PsGoogleAnalyticsTemplateHandler
+    parent: AxeptiocookiesAddon\Handler\Template\AbstractTemplateHandler
+    public: true

--- a/src/API/Response/Object/Vendor.php
+++ b/src/API/Response/Object/Vendor.php
@@ -47,6 +47,11 @@ class Vendor extends AbstractObject
     protected $url;
 
     /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
      * @var bool
      */
     protected $isRequired = false;
@@ -72,6 +77,10 @@ class Vendor extends AbstractObject
 
         if (!empty($json['data']['url'])) {
             $this->setUrl($json['data']['url']);
+        }
+
+        if (!empty($json['data']['title'])) {
+            $this->setTitle($json['data']['title']);
         }
 
         return $this;
@@ -173,6 +182,26 @@ class Vendor extends AbstractObject
     public function setIsRequired($isRequired)
     {
         $this->isRequired = $isRequired;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     *
+     * @return Vendor
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
 
         return $this;
     }

--- a/src/Factory/TemplateReplacementFactory.php
+++ b/src/Factory/TemplateReplacementFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace AxeptiocookiesAddon\Factory;
+
+use AxeptiocookiesAddon\Handler\Template\AbstractTemplateHandler;
+use AxeptiocookiesAddon\Handler\Template\PsGoogleAnalyticsTemplateHandler;
+use AxeptiocookiesAddon\Model\Constant\TemplateFile;
+use AxeptiocookiesAddon\Utils\ServiceContainer;
+
+class TemplateReplacementFactory
+{
+    /**
+     * @param string $template
+     *
+     * @return AbstractTemplateHandler|object|null
+     */
+    public function getHandler($template)
+    {
+        switch ($template) {
+            case TemplateFile::PS_GOOGLE_ANALYTICS:
+                return ServiceContainer::getInstance()->get(PsGoogleAnalyticsTemplateHandler::class);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Handler/Template/AbstractTemplateHandler.php
+++ b/src/Handler/Template/AbstractTemplateHandler.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace AxeptiocookiesAddon\Handler\Template;
+
+abstract class AbstractTemplateHandler
+{
+    /**
+     * @var \Smarty_Internal_Template
+     */
+    protected $template;
+
+    /**
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * @return string
+     */
+    public function handle()
+    {
+        try {
+            return $this->getPlaceholder();
+        } catch (\Exception $exception) {
+            return $this->source;
+        }
+    }
+
+    protected function getPlaceholder()
+    {
+        $tpl = \Context::getContext()
+            ->smarty
+            ->createTemplate('module:axeptiocookies/views/templates/front/template/placeholder.tpl')
+            ->assign([
+                'id' => uniqid(),
+                'templateCode' => base64_encode($this->source),
+                'module' => $this->getModule(),
+            ]);
+
+        return $tpl->fetch();
+    }
+
+    /**
+     * @param \Smarty_Internal_Template $template
+     *
+     * @return AbstractTemplateHandler
+     */
+    public function setTemplate(\Smarty_Internal_Template $template)
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+
+    /**
+     * @param string $source
+     *
+     * @return AbstractTemplateHandler
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    abstract protected function getModule();
+}

--- a/src/Handler/Template/PsGoogleAnalyticsTemplateHandler.php
+++ b/src/Handler/Template/PsGoogleAnalyticsTemplateHandler.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace AxeptiocookiesAddon\Handler\Template;
+
+use AxeptiocookiesAddon\Service\HookService;
+
+class PsGoogleAnalyticsTemplateHandler extends AbstractTemplateHandler
+{
+    protected function getModule()
+    {
+        return HookService::PS_MODULE_PREFIX . 'ps_googleanalytics';
+    }
+}

--- a/src/Hook/CommonHook.php
+++ b/src/Hook/CommonHook.php
@@ -20,6 +20,7 @@
 namespace AxeptiocookiesAddon\Hook;
 
 use AxeptiocookiesAddon\Service\HookService;
+use AxeptiocookiesAddon\Smarty\CookiesCompletePrefilter;
 use AxeptiocookiesAddon\Utils\ServiceContainer;
 use AxeptiocookiesClasslib\Hook\AbstractHook;
 
@@ -53,6 +54,17 @@ class CommonHook extends AbstractHook
 
     public function actionDispatcherBefore($params)
     {
+        if ($params['controller_type'] != \Dispatcher::FC_ADMIN) {
+            \Context::getContext()->smarty->registerFilter(
+                'output',
+                [
+                    CookiesCompletePrefilter::class,
+                    'handleCookiesComplete',
+                ],
+                'handleCookiesComplete'
+            );
+        }
+
         if ($params['controller_type'] != \Dispatcher::FC_FRONT) {
             return;
         }

--- a/src/Model/Constant/TemplateFile.php
+++ b/src/Model/Constant/TemplateFile.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace AxeptiocookiesAddon\Model\Constant;
+
+class TemplateFile
+{
+    const PS_GOOGLE_ANALYTICS = 'modules/ps_googleanalytics/views/templates/hook/ps_googleanalytics.tpl';
+}

--- a/src/Model/Constant/WhiteListModules.php
+++ b/src/Model/Constant/WhiteListModules.php
@@ -25,6 +25,12 @@ class WhiteListModules
         'axeptiocookies',
     ];
 
+    const PRELOADED_MODULES_HOOKS = [
+      'ps_googleanalytics' => [
+          'displayHeader',
+      ],
+    ];
+
     const WHITE_LIST_HOOKS = [
         'moduleRoutes',
         'additionalCustomerFormFields',

--- a/src/Model/Integration/IntegrationModel.php
+++ b/src/Model/Integration/IntegrationModel.php
@@ -37,6 +37,11 @@ class IntegrationModel implements \JsonSerializable
     protected $moduleStep;
 
     /**
+     * @var string
+     */
+    protected $platform = 'plugin-prestashop';
+
+    /**
      * @return mixed
      */
     public function getClientId()
@@ -156,6 +161,26 @@ class IntegrationModel implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getPlatform()
+    {
+        return $this->platform;
+    }
+
+    /**
+     * @param string $platform
+     *
+     * @return IntegrationModel
+     */
+    public function setPlatform($platform)
+    {
+        $this->platform = $platform;
+
+        return $this;
+    }
+
     public function jsonSerialize()
     {
         return get_object_vars($this);
@@ -170,6 +195,7 @@ class IntegrationModel implements \JsonSerializable
         $obj->setAllVendorsCookieName($array['allVendorsCookieName']);
         $obj->setAuthorizedVendorsCookieName($array['authorizedVendorsCookieName']);
         $obj->setModuleStep($array['moduleStep']);
+        $obj->setPlatform(empty($array['platform']) ? '' : $array['platform']);
 
         return $obj;
     }
@@ -183,6 +209,7 @@ class IntegrationModel implements \JsonSerializable
             'allVendorsCookieName' => $this->getAllVendorsCookieName(),
             'authorizedVendorsCookieName' => $this->getAuthorizedVendorsCookieName(),
             'moduleStep' => empty($this->getModuleStep()) ? [] : $this->getModuleStep()->toArray(),
+            'platform' => $this->getPlatform(),
         ];
     }
 }

--- a/src/Service/CookieService.php
+++ b/src/Service/CookieService.php
@@ -101,6 +101,9 @@ class CookieService
             }
 
             foreach ($hookList as $index => $hookItem) {
+                if ($this->isPreloadedHook($hookItem['module'], \Hook::getNameById($hookItem['id_hook']))) {
+                    continue;
+                }
                 if ($hookItem['module'] == $moduleName) {
                     unset($hookList[$index]);
                     break;
@@ -128,5 +131,15 @@ class CookieService
     public function clearContextRequestCache()
     {
         static::$contextModules = [];
+    }
+
+    public function isPreloadedHook($moduleName, $hookName)
+    {
+        $preloadedHooks = WhiteListModules::PRELOADED_MODULES_HOOKS;
+        if (!isset($preloadedHooks[$moduleName])) {
+            return false;
+        }
+
+        return in_array($hookName, $preloadedHooks[$moduleName]);
     }
 }

--- a/src/Service/HookService.php
+++ b/src/Service/HookService.php
@@ -163,7 +163,11 @@ class HookService
             $vendor = new VendorModel();
             $vendor->setDescription(!empty($module['description']) ? $module['description'] : '');
             $vendor->setName(self::PS_MODULE_PREFIX . $module['name']);
-            $vendor->setTitle(!empty($module['displayName']) ? $module['displayName'] : $module['name']);
+            if (!empty($module['recommended']) && !empty($module['recommended']->getTitle()) && empty(\Context::getContext()->employee)) {
+                $vendor->setTitle($module['recommended']->getTitle());
+            } else {
+                $vendor->setTitle(!empty($module['displayName']) ? $module['displayName'] : $module['name']);
+            }
             $vendor->setType(!empty($module['tab']) ? $module['tab'] : '');
             if (!empty($module['image'])) {
                 $vendor->setImage($module['image']);

--- a/src/Smarty/CookiesCompletePrefilter.php
+++ b/src/Smarty/CookiesCompletePrefilter.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+namespace AxeptiocookiesAddon\Smarty;
+
+use AxeptiocookiesAddon\Factory\TemplateReplacementFactory;
+use AxeptiocookiesAddon\Utils\ServiceContainer;
+
+class CookiesCompletePrefilter
+{
+    /**
+     * @param string $source
+     * @param \Smarty_Internal_Template $template
+     *
+     * @return mixed|void
+     */
+    public static function handleCookiesComplete($source, $template)
+    {
+        /** @var TemplateReplacementFactory $templateReplacementFactory */
+        $templateReplacementFactory = ServiceContainer::getInstance()->get(TemplateReplacementFactory::class);
+        $handler = $templateReplacementFactory->getHandler($template->template_resource);
+        if (empty($handler)) {
+            return $source;
+        }
+
+        return $handler
+            ->setSource($source)
+            ->setTemplate($template)
+            ->handle();
+    }
+}

--- a/upgrade/upgrade-2.0.6.php
+++ b/upgrade/upgrade-2.0.6.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ */
+
+/**
+ * @param Axeptiocookies $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_6($module)
+{
+    try {
+        $cache = new \AxeptiocookiesAddon\Cache\ProjectCache();
+        $cache->cleanCacheDirectory();
+    } catch (Exception $e) {
+        return false;
+    }
+
+    return true;
+}

--- a/views/_dev/package-lock.json
+++ b/views/_dev/package-lock.json
@@ -8,36 +8,36 @@
       "name": "dev",
       "version": "0.0.0",
       "dependencies": {
-        "@vueuse/core": "^10.5.0",
-        "axios": "^1.5.1",
+        "@vueuse/core": "^10.7.0",
+        "axios": "^1.6.2",
         "floating-vue": "^2.0.0-beta.24",
         "jquery": "^3.7.1",
         "pinia": "^2.1.7",
-        "prestakit": "^1.2.5",
+        "prestakit": "^1.2.6",
         "qs": "^6.11.2",
-        "vue": "^3.3.4",
-        "vue-multiselect": "^3.0.0-beta.2",
+        "vue": "^3.3.12",
+        "vue-multiselect": "^3.0.0-beta.3",
         "vue-router": "^4.2.5"
       },
       "devDependencies": {
         "@tsconfig/node18": "^2.0.1",
         "@types/bootstrap": "^4.6.3",
-        "@types/jquery": "^3.5.22",
+        "@types/jquery": "^3.5.29",
         "@types/node": "^18.16.17",
-        "@types/qs": "^6.9.7",
-        "@vitejs/plugin-vue": "^4.2.3",
-        "@vue/tsconfig": "^0.4.0",
+        "@types/qs": "^6.9.10",
+        "@vitejs/plugin-vue": "^4.5.2",
+        "@vue/tsconfig": "^0.5.1",
         "npm-run-all": "^4.1.5",
-        "sass": "^1.69.3",
-        "typescript": "^5.0.2",
-        "vite": "^4.4.11",
-        "vue-tsc": "^1.8.19"
+        "sass": "^1.69.5",
+        "typescript": "^5.3.3",
+        "vite": "^4.5.1",
+        "vue-tsc": "^1.8.25"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -445,9 +445,9 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.22",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.22.tgz",
-      "integrity": "sha512-ISQFeUK5GwRftLK4PVvKTWEVCxZ2BpaqBz0TWkIq5w4vGojxZP9+XkqgcPjxoqmPeew+HLyWthCBvK7GdF5NYA==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
+      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dev": true,
       "dependencies": {
         "@types/sizzle": "*"
@@ -460,9 +460,9 @@
       "dev": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
       "dev": true
     },
     "node_modules/@types/sizzle": {
@@ -472,94 +472,95 @@
       "dev": true
     },
     "node_modules/@types/web-bluetooth": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
-      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw=="
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.4.0.tgz",
-      "integrity": "sha512-xdguqb+VUwiRpSg+nsc2HtbAUSGak25DXYvpQQi4RVU1Xq1uworyoH/md9Rfd8zMmPR/pSghr309QNcftUVseg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
+      "integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.0.0",
+        "vite": "^4.0.0 || ^5.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.4.tgz",
-      "integrity": "sha512-Na69qA6uwVIdA0rHuOc2W3pHtVQQO8hCNim7FOaKNpRJh0oAFnu5r9i7Oopo5C4cnELZkPNjTrbmpcCTiW+CMQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "1.10.4"
+        "@volar/source-map": "1.11.1"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.4.tgz",
-      "integrity": "sha512-RxZdUEL+pV8p+SMqnhVjzy5zpb1QRZTlcwSk4bdcBO7yOu4rtEWqDGahVCEj4CcXour+0yJUMrMczfSCpP9Uxg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
       "dev": true,
       "dependencies": {
         "muggle-string": "^0.3.1"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.4.tgz",
-      "integrity": "sha512-BCCUEBASBEMCrz7qmNSi2hBEWYsXD0doaktRKpmmhvb6XntM2sAWYu6gbyK/MluLDgluGLFiFRpWgobgzUqolg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "1.10.4"
+        "@volar/language-core": "1.11.1",
+        "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
       "dependencies": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz",
+      "integrity": "sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==",
       "dependencies": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.12.tgz",
+      "integrity": "sha512-yy5b9e7b79dsGbMmglCe/YnhCQgBkHO7Uf6JfjWPSf2/5XH+MKn18LhzhHyxbHdJgnA4lZCqtXzLaJz8Pd8lMw==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/reactivity-transform": "3.3.12",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.12.tgz",
+      "integrity": "sha512-adCiMJPznfWcQyk/9HSuXGja859IaMV+b8UNSVzDatqv7h0PvT9BEeS22+gjkWofDiSg5d78/ZLls3sLA+cn3A==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -568,18 +569,19 @@
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "node_modules/@vue/language-core": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.19.tgz",
-      "integrity": "sha512-nt3dodGs97UM6fnxeQBazO50yYCKBK53waFWB3qMbLmR6eL3aUryZgQtZoBe1pye17Wl8fs9HysV3si6xMgndQ==",
+      "version": "1.8.25",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.25.tgz",
+      "integrity": "sha512-NJk/5DnAZlpvXX8BdWmHI45bWGLViUaS3R/RMrmFSvFMSbJKuEODpM4kR0F0Ofv5SFzCWuNiMhxameWpVdQsnA==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "~1.10.4",
-        "@volar/source-map": "~1.10.4",
+        "@volar/language-core": "~1.11.1",
+        "@volar/source-map": "~1.11.1",
         "@vue/compiler-dom": "^3.3.0",
-        "@vue/reactivity": "^3.3.0",
         "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
         "minimatch": "^9.0.3",
         "muggle-string": "^0.3.1",
+        "path-browserify": "^1.0.1",
         "vue-template-compiler": "^2.7.14"
       },
       "peerDependencies": {
@@ -616,85 +618,75 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.12.tgz",
+      "integrity": "sha512-vOJORzO8DlIx88cgTnMLIf2GlLYpoXAKsuoQsK6SGdaqODjxO129pVPTd2s/N/Mb6KKZEFIHIEwWGmtN4YPs+g==",
       "dependencies": {
-        "@vue/shared": "3.3.4"
+        "@vue/shared": "3.3.12"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.12.tgz",
+      "integrity": "sha512-g5TijmML7FyKkLt6QnpqNmA4KD7K/T5SbXa88Bhq+hydNQEkzA8veVXWAQuNqg9rjaFYD0rPf0a9NofKA0ENgg==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "magic-string": "^0.30.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.12.tgz",
+      "integrity": "sha512-5iL4w7MZrSGKEZU2wFAYhDZdZmgn+s//73EfgDXW1M+ZUOl36md7tlWp1QFK/ladiq4FvQ82shVjo0KiPDPr0A==",
       "dependencies": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/reactivity": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.12.tgz",
+      "integrity": "sha512-8mMzqiIdl+IYa/OXwKwk6/4ebLq7cYV1pUcwCSwBK2KerUa6cwGosen5xrCL9f8o2DJ9TfPFwbPEvH7OXzUpoA==",
       "dependencies": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
+        "@vue/runtime-core": "3.3.12",
+        "@vue/shared": "3.3.12",
+        "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.12.tgz",
+      "integrity": "sha512-OZ0IEK5TU5GXb5J8/wSplyxvGGdIcwEmS8EIO302Vz8K6fGSgSJTU54X0Sb6PaefzZdiN3vHsLXO8XIeF8crQQ==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/shared": "3.3.12"
       },
       "peerDependencies": {
-        "vue": "3.3.4"
+        "vue": "3.3.12"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
     },
     "node_modules/@vue/tsconfig": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.4.0.tgz",
-      "integrity": "sha512-CPuIReonid9+zOG/CGTT05FXrPYATEqoDGNrEaqS4hwcw5BUNM2FguC0mOwJD4Jr16UpRVl9N0pY3P+srIbqmg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
+      "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
     },
-    "node_modules/@vue/typescript": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.19.tgz",
-      "integrity": "sha512-k/SHeeQROUgqsxyHQ8Cs3Zz5TnX57p7BcBDVYR2E0c61QL2DJ2G8CsaBremmNGuGE6o1R5D50IHIxFmroMz8iw==",
-      "dev": true,
-      "dependencies": {
-        "@volar/typescript": "~1.10.4",
-        "@vue/language-core": "1.8.19"
-      }
-    },
     "node_modules/@vueuse/core": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
-      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.0.tgz",
+      "integrity": "sha512-4EUDESCHtwu44ZWK3Gc/hZUVhVo/ysvdtwocB5vcauSV4B7NiGY5972WnsojB3vRNdxvAt7kzJWE2h9h7C9d5w==",
       "dependencies": {
-        "@types/web-bluetooth": "^0.0.18",
-        "@vueuse/metadata": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.7.0",
+        "@vueuse/shared": "10.7.0",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -727,17 +719,17 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
-      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.0.tgz",
+      "integrity": "sha512-GlaH7tKP2iBCZ3bHNZ6b0cl9g0CJK8lttkBNUX156gWvNYhTKEtbweWLm9rxCPIiwzYcr/5xML6T8ZUEt+DkvA==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
-      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.0.tgz",
+      "integrity": "sha512-kc00uV6CiaTdc3i1CDC4a3lBxzaBE9AgYNtFN87B5OOscqeWElj/uza8qVDmk7/U8JbqoONLbtqiLJ5LGRuqlw==",
       "dependencies": {
         "vue-demi": ">=0.14.6"
       },
@@ -847,9 +839,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -991,6 +983,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1014,9 +1012,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -1871,9 +1869,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -1992,6 +1990,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-key": {
       "version": "2.0.1",
@@ -2119,9 +2123,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2137,7 +2141,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -2286,9 +2290,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.69.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.3.tgz",
-      "integrity": "sha512-X99+a2iGdXkdWn1akFPs0ZmelUzyAQfvqYc2P/MPTrJRuIRoTffGzT9W9nFqG00S+c8hXzVmgxhUuHFdrwxkhQ==",
+      "version": "1.69.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+      "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -2586,9 +2590,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2624,9 +2628,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
-      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -2679,21 +2683,29 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.12.tgz",
+      "integrity": "sha512-jYNv2QmET2OTHsFzfWHMnqgCfqL4zfo97QwofdET+GBRCHhSCHuMTTvNIgeSn0/xF3JRT5OGah6MDwUFN7MPlg==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-sfc": "3.3.12",
+        "@vue/runtime-dom": "3.3.12",
+        "@vue/server-renderer": "3.3.12",
+        "@vue/shared": "3.3.12"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-multiselect": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-3.0.0-beta.2.tgz",
-      "integrity": "sha512-TFVHtI/KdWoD3Opzbkso8OIqkZlZEqFF7f2jlYx1ttgC4Jv/48IGlU5zn6cBR4p2bFDFGCHF5SkLCaadLhnBPQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-3.0.0-beta.3.tgz",
+      "integrity": "sha512-P7Fx+ovVF7WMERSZ0lw6N3p4H4bnQ3NcaY3ORjzFPv0r/6lpIqvFWmK9Xnwze9mgAvmNV1foI1VWrBmjnfBTLQ==",
       "engines": {
         "node": ">= 4.0.0",
         "npm": ">= 3.0.0"
@@ -2722,9 +2734,9 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "dependencies": {
         "de-indent": "^1.0.2",
@@ -2732,13 +2744,13 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.19.tgz",
-      "integrity": "sha512-tacMQLQ0CXAfbhRycCL5sWIy1qujXaIEtP1hIQpzHWOUuICbtTj9gJyFf91PvzG5KCNIkA5Eg7k2Fmgt28l5DQ==",
+      "version": "1.8.25",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.25.tgz",
+      "integrity": "sha512-lHsRhDc/Y7LINvYhZ3pv4elflFADoEOo67vfClAfF2heVHpHmVquLSjojgCSIwzA4F0Pc4vowT/psXCYcfk+iQ==",
       "dev": true,
       "dependencies": {
-        "@vue/language-core": "1.8.19",
-        "@vue/typescript": "1.8.19",
+        "@volar/typescript": "~1.11.1",
+        "@vue/language-core": "1.8.25",
         "semver": "^7.5.4"
       },
       "bin": {
@@ -2819,9 +2831,9 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ=="
     },
     "@esbuild/android-arm": {
       "version": "0.18.20",
@@ -3025,9 +3037,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.5.22",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.22.tgz",
-      "integrity": "sha512-ISQFeUK5GwRftLK4PVvKTWEVCxZ2BpaqBz0TWkIq5w4vGojxZP9+XkqgcPjxoqmPeew+HLyWthCBvK7GdF5NYA==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
+      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -3040,9 +3052,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.8",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
       "dev": true
     },
     "@types/sizzle": {
@@ -3052,88 +3064,89 @@
       "dev": true
     },
     "@types/web-bluetooth": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
-      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw=="
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "@vitejs/plugin-vue": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.4.0.tgz",
-      "integrity": "sha512-xdguqb+VUwiRpSg+nsc2HtbAUSGak25DXYvpQQi4RVU1Xq1uworyoH/md9Rfd8zMmPR/pSghr309QNcftUVseg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
+      "integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
       "dev": true,
       "requires": {}
     },
     "@volar/language-core": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.4.tgz",
-      "integrity": "sha512-Na69qA6uwVIdA0rHuOc2W3pHtVQQO8hCNim7FOaKNpRJh0oAFnu5r9i7Oopo5C4cnELZkPNjTrbmpcCTiW+CMQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
       "dev": true,
       "requires": {
-        "@volar/source-map": "1.10.4"
+        "@volar/source-map": "1.11.1"
       }
     },
     "@volar/source-map": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.4.tgz",
-      "integrity": "sha512-RxZdUEL+pV8p+SMqnhVjzy5zpb1QRZTlcwSk4bdcBO7yOu4rtEWqDGahVCEj4CcXour+0yJUMrMczfSCpP9Uxg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
       "dev": true,
       "requires": {
         "muggle-string": "^0.3.1"
       }
     },
     "@volar/typescript": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.4.tgz",
-      "integrity": "sha512-BCCUEBASBEMCrz7qmNSi2hBEWYsXD0doaktRKpmmhvb6XntM2sAWYu6gbyK/MluLDgluGLFiFRpWgobgzUqolg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
       "dev": true,
       "requires": {
-        "@volar/language-core": "1.10.4"
+        "@volar/language-core": "1.11.1",
+        "path-browserify": "^1.0.1"
       }
     },
     "@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.12.tgz",
+      "integrity": "sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==",
       "requires": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz",
+      "integrity": "sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==",
       "requires": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.12.tgz",
+      "integrity": "sha512-yy5b9e7b79dsGbMmglCe/YnhCQgBkHO7Uf6JfjWPSf2/5XH+MKn18LhzhHyxbHdJgnA4lZCqtXzLaJz8Pd8lMw==",
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/reactivity-transform": "3.3.12",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.12.tgz",
+      "integrity": "sha512-adCiMJPznfWcQyk/9HSuXGja859IaMV+b8UNSVzDatqv7h0PvT9BEeS22+gjkWofDiSg5d78/ZLls3sLA+cn3A==",
       "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "@vue/devtools-api": {
@@ -3142,18 +3155,19 @@
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
     },
     "@vue/language-core": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.19.tgz",
-      "integrity": "sha512-nt3dodGs97UM6fnxeQBazO50yYCKBK53waFWB3qMbLmR6eL3aUryZgQtZoBe1pye17Wl8fs9HysV3si6xMgndQ==",
+      "version": "1.8.25",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.25.tgz",
+      "integrity": "sha512-NJk/5DnAZlpvXX8BdWmHI45bWGLViUaS3R/RMrmFSvFMSbJKuEODpM4kR0F0Ofv5SFzCWuNiMhxameWpVdQsnA==",
       "dev": true,
       "requires": {
-        "@volar/language-core": "~1.10.4",
-        "@volar/source-map": "~1.10.4",
+        "@volar/language-core": "~1.11.1",
+        "@volar/source-map": "~1.11.1",
         "@vue/compiler-dom": "^3.3.0",
-        "@vue/reactivity": "^3.3.0",
         "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
         "minimatch": "^9.0.3",
         "muggle-string": "^0.3.1",
+        "path-browserify": "^1.0.1",
         "vue-template-compiler": "^2.7.14"
       },
       "dependencies": {
@@ -3178,82 +3192,72 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.12.tgz",
+      "integrity": "sha512-vOJORzO8DlIx88cgTnMLIf2GlLYpoXAKsuoQsK6SGdaqODjxO129pVPTd2s/N/Mb6KKZEFIHIEwWGmtN4YPs+g==",
       "requires": {
-        "@vue/shared": "3.3.4"
+        "@vue/shared": "3.3.12"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.12.tgz",
+      "integrity": "sha512-g5TijmML7FyKkLt6QnpqNmA4KD7K/T5SbXa88Bhq+hydNQEkzA8veVXWAQuNqg9rjaFYD0rPf0a9NofKA0ENgg==",
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.12",
+        "@vue/shared": "3.3.12",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "magic-string": "^0.30.5"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.12.tgz",
+      "integrity": "sha512-5iL4w7MZrSGKEZU2wFAYhDZdZmgn+s//73EfgDXW1M+ZUOl36md7tlWp1QFK/ladiq4FvQ82shVjo0KiPDPr0A==",
       "requires": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/reactivity": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.12.tgz",
+      "integrity": "sha512-8mMzqiIdl+IYa/OXwKwk6/4ebLq7cYV1pUcwCSwBK2KerUa6cwGosen5xrCL9f8o2DJ9TfPFwbPEvH7OXzUpoA==",
       "requires": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
+        "@vue/runtime-core": "3.3.12",
+        "@vue/shared": "3.3.12",
+        "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.12.tgz",
+      "integrity": "sha512-OZ0IEK5TU5GXb5J8/wSplyxvGGdIcwEmS8EIO302Vz8K6fGSgSJTU54X0Sb6PaefzZdiN3vHsLXO8XIeF8crQQ==",
       "requires": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-ssr": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.12.tgz",
+      "integrity": "sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag=="
     },
     "@vue/tsconfig": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.4.0.tgz",
-      "integrity": "sha512-CPuIReonid9+zOG/CGTT05FXrPYATEqoDGNrEaqS4hwcw5BUNM2FguC0mOwJD4Jr16UpRVl9N0pY3P+srIbqmg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
+      "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
     },
-    "@vue/typescript": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.19.tgz",
-      "integrity": "sha512-k/SHeeQROUgqsxyHQ8Cs3Zz5TnX57p7BcBDVYR2E0c61QL2DJ2G8CsaBremmNGuGE6o1R5D50IHIxFmroMz8iw==",
-      "dev": true,
-      "requires": {
-        "@volar/typescript": "~1.10.4",
-        "@vue/language-core": "1.8.19"
-      }
-    },
     "@vueuse/core": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
-      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.0.tgz",
+      "integrity": "sha512-4EUDESCHtwu44ZWK3Gc/hZUVhVo/ysvdtwocB5vcauSV4B7NiGY5972WnsojB3vRNdxvAt7kzJWE2h9h7C9d5w==",
       "requires": {
-        "@types/web-bluetooth": "^0.0.18",
-        "@vueuse/metadata": "10.5.0",
-        "@vueuse/shared": "10.5.0",
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.7.0",
+        "@vueuse/shared": "10.7.0",
         "vue-demi": ">=0.14.6"
       },
       "dependencies": {
@@ -3266,14 +3270,14 @@
       }
     },
     "@vueuse/metadata": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
-      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw=="
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.0.tgz",
+      "integrity": "sha512-GlaH7tKP2iBCZ3bHNZ6b0cl9g0CJK8lttkBNUX156gWvNYhTKEtbweWLm9rxCPIiwzYcr/5xML6T8ZUEt+DkvA=="
     },
     "@vueuse/shared": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
-      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.0.tgz",
+      "integrity": "sha512-kc00uV6CiaTdc3i1CDC4a3lBxzaBE9AgYNtFN87B5OOscqeWElj/uza8qVDmk7/U8JbqoONLbtqiLJ5LGRuqlw==",
       "requires": {
         "vue-demi": ">=0.14.6"
       },
@@ -3342,9 +3346,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -3447,6 +3451,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3467,9 +3477,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -4080,9 +4090,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4163,6 +4173,12 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -4230,11 +4246,11 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -4340,9 +4356,9 @@
       }
     },
     "sass": {
-      "version": "1.69.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.3.tgz",
-      "integrity": "sha512-X99+a2iGdXkdWn1akFPs0ZmelUzyAQfvqYc2P/MPTrJRuIRoTffGzT9W9nFqG00S+c8hXzVmgxhUuHFdrwxkhQ==",
+      "version": "1.69.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+      "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -4562,9 +4578,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true
     },
     "unbox-primitive": {
@@ -4590,9 +4606,9 @@
       }
     },
     "vite": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
-      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
@@ -4602,21 +4618,21 @@
       }
     },
     "vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.12.tgz",
+      "integrity": "sha512-jYNv2QmET2OTHsFzfWHMnqgCfqL4zfo97QwofdET+GBRCHhSCHuMTTvNIgeSn0/xF3JRT5OGah6MDwUFN7MPlg==",
       "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.3.12",
+        "@vue/compiler-sfc": "3.3.12",
+        "@vue/runtime-dom": "3.3.12",
+        "@vue/server-renderer": "3.3.12",
+        "@vue/shared": "3.3.12"
       }
     },
     "vue-multiselect": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-3.0.0-beta.2.tgz",
-      "integrity": "sha512-TFVHtI/KdWoD3Opzbkso8OIqkZlZEqFF7f2jlYx1ttgC4Jv/48IGlU5zn6cBR4p2bFDFGCHF5SkLCaadLhnBPQ=="
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-3.0.0-beta.3.tgz",
+      "integrity": "sha512-P7Fx+ovVF7WMERSZ0lw6N3p4H4bnQ3NcaY3ORjzFPv0r/6lpIqvFWmK9Xnwze9mgAvmNV1foI1VWrBmjnfBTLQ=="
     },
     "vue-resize": {
       "version": "2.0.0-alpha.1",
@@ -4633,9 +4649,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -4643,13 +4659,13 @@
       }
     },
     "vue-tsc": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.19.tgz",
-      "integrity": "sha512-tacMQLQ0CXAfbhRycCL5sWIy1qujXaIEtP1hIQpzHWOUuICbtTj9gJyFf91PvzG5KCNIkA5Eg7k2Fmgt28l5DQ==",
+      "version": "1.8.25",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.25.tgz",
+      "integrity": "sha512-lHsRhDc/Y7LINvYhZ3pv4elflFADoEOo67vfClAfF2heVHpHmVquLSjojgCSIwzA4F0Pc4vowT/psXCYcfk+iQ==",
       "dev": true,
       "requires": {
-        "@vue/language-core": "1.8.19",
-        "@vue/typescript": "1.8.19",
+        "@volar/typescript": "~1.11.1",
+        "@vue/language-core": "1.8.25",
         "semver": "^7.5.4"
       },
       "dependencies": {

--- a/views/_dev/package.json
+++ b/views/_dev/package.json
@@ -11,29 +11,29 @@
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "@vueuse/core": "^10.5.0",
-    "axios": "^1.5.1",
+    "@vueuse/core": "^10.7.0",
+    "axios": "^1.6.2",
     "floating-vue": "^2.0.0-beta.24",
     "jquery": "^3.7.1",
     "pinia": "^2.1.7",
-    "prestakit": "^1.2.5",
+    "prestakit": "^1.2.6",
     "qs": "^6.11.2",
-    "vue": "^3.3.4",
-    "vue-multiselect": "^3.0.0-beta.2",
+    "vue": "^3.3.12",
+    "vue-multiselect": "^3.0.0-beta.3",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@tsconfig/node18": "^2.0.1",
     "@types/bootstrap": "^4.6.3",
-    "@types/jquery": "^3.5.22",
+    "@types/jquery": "^3.5.29",
     "@types/node": "^18.16.17",
-    "@types/qs": "^6.9.7",
-    "@vitejs/plugin-vue": "^4.2.3",
-    "@vue/tsconfig": "^0.4.0",
+    "@types/qs": "^6.9.10",
+    "@vitejs/plugin-vue": "^4.5.2",
+    "@vue/tsconfig": "^0.5.1",
     "npm-run-all": "^4.1.5",
-    "sass": "^1.69.3",
-    "typescript": "^5.0.2",
-    "vite": "^4.4.11",
-    "vue-tsc": "^1.8.19"
+    "sass": "^1.69.5",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.25"
   }
 }

--- a/views/templates/front/hook/footer.tpl
+++ b/views/templates/front/hook/footer.tpl
@@ -69,7 +69,7 @@
         }
         for (const [key, value] of Object.entries(choices)) {
           if (!isCookiesSet || (typeof currentCookiesConfig[key] === 'undefined' || currentCookiesConfig[key] !== value)) {
-            window.location.reload();
+            // window.location.reload();
             break;
           }
         }

--- a/views/templates/front/hook/footer.tpl
+++ b/views/templates/front/hook/footer.tpl
@@ -23,7 +23,8 @@
       cookiesVersion: "{$integration.cookiesVersion|escape:'htmlall':'UTF-8'}",
       jsonCookieName: "{$integration.jsonCookieName|escape:'htmlall':'UTF-8'}",
       allVendorsCookieName: "{$integration.allVendorsCookieName|escape:'htmlall':'UTF-8'}",
-      authorizedVendorsCookieName: "{$integration.authorizedVendorsCookieName|escape:'htmlall':'UTF-8'}"
+      authorizedVendorsCookieName: "{$integration.authorizedVendorsCookieName|escape:'htmlall':'UTF-8'}",
+      platform: "{$integration.platform|escape:'htmlall':'UTF-8'}"
       //]]>
     };
 

--- a/views/templates/front/template/placeholder.tpl
+++ b/views/templates/front/template/placeholder.tpl
@@ -1,0 +1,40 @@
+{**
+ * Copyright since 2022 Axeptio
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to tech@202-ecommerce.com so we can send you a copy immediately.
+ *
+ * @author    202 ecommerce <tech@202-ecommerce.com>
+ * @copyright 2022 Axeptio
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License (AFL 3.0)
+ *}
+
+<meta data-id="{$id|escape:'htmlall':'UTF-8'}">
+<script>
+  //<![CDATA[
+  (_axcb = window._axcb || []).push(function (sdk) {
+    var currentCookiesConfig = window.axeptioSDK.userPreferencesManager.choices;
+    var currentModule = "{$module|escape:'htmlall':'UTF-8'}";
+    sdk.on('cookies:complete', function(choices) {
+      currentCookiesConfig = Object.assign({
+      }, choices);
+      for (const [key, value] of Object.entries(currentCookiesConfig)) {
+        if (typeof value === 'undefined') {
+          currentCookiesConfig[key] = false;
+        }
+      }
+      if (currentCookiesConfig[currentModule]) {
+        var placeholderItem = document.querySelector('[data-id="{$id|escape:'htmlall':'UTF-8'}"]');
+        placeholderItem.outerHTML = atob("{$templateCode|escape:'htmlall':'UTF-8'}");
+      }
+    });
+  });
+  //]]>
+</script>


### PR DESCRIPTION
* [#39456] Removed reload of page.

* Fixed tests

* Fixed tests

* Bump webpack from 5.75.0 to 5.76.0 (#18)

Bumps [webpack](https://github.com/webpack/webpack) from 5.75.0 to 5.76.0.
- [Release notes](https://github.com/webpack/webpack/releases)
- [Commits](https://github.com/webpack/webpack/compare/v5.75.0...v5.76.0)

---
updated-dependencies:
- dependency-name: webpack dependency-type: direct:development ...




* Fixed router links; refs #90510000008678202

* Merge pull request #19

* Fixed special characters in module list names; refs #41885

* Fixed special characters in module list names; refs #41885

* Started to add Vendor DB; refs #42021

* Fixed validation errors; refs #42021

* Fixed validation errors; refs #42021

* Cover report; refs #42021

* Fixed shops simple card errors; refs #42021

* Test validator fix; refs #42021

* Fixed validation errors; refs #42021

* Fixed validation errors; refs #42021

* Fixed validation errors; refs #42021

* Fixed validation errors; refs #42021

* Fixed validation errors; refs #42021

* Removed unnecessary configs; refs #42021

* Fixed sonar errors; refs #42021

* Fixed project id request error over http; refs #42728

* [#39456] Removed reload of page.

* Fixed some errors; refs #39456

* Removed unused hook; refs #39456

---------